### PR TITLE
cicd: Add sekin repository trigger and improve .gitignore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,3 +430,25 @@ jobs:
           body: ${{ steps.release_notes.outputs.notes }}
           draft: false
           prerelease: false
+
+  trigger_sekin_update:
+    needs: build_and_push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sekin repository update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          repository: kiracore/sekin
+          event-type: interx_release
+          client-payload: |
+            {
+              "version": "${{ needs.build_and_push.outputs.version }}",
+              "manager_image": "ghcr.io/kiracore/interx/manager:${{ needs.build_and_push.outputs.version }}",
+              "proxy_image": "ghcr.io/kiracore/interx/proxy:${{ needs.build_and_push.outputs.version }}",
+              "storage_image": "ghcr.io/kiracore/interx/storage:${{ needs.build_and_push.outputs.version }}",
+              "cosmos_indexer_image": "ghcr.io/kiracore/interx/cosmos-indexer:${{ needs.build_and_push.outputs.version }}",
+              "cosmos_interaction_image": "ghcr.io/kiracore/interx/cosmos-interaction:${{ needs.build_and_push.outputs.version }}",
+              "ethereum_indexer_image": "ghcr.io/kiracore/interx/ethereum-indexer:${{ needs.build_and_push.outputs.version }}",
+              "ethereum_interaction_image": "ghcr.io/kiracore/interx/ethereum-interaction:${{ needs.build_and_push.outputs.version }}"
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,21 @@
+# IDE and Editor
 .vscode/
-.DS_Store
 .ides/
+.DS_Store
+
+# Docker and Infrastructure
+docker-compose-unified.yml
+init_network.sh
+
+# Dependencies
+sekai/
+
+# Logs
+manager/logs/
+proxy/logs/
+
+# Storage
+worker/sai-storage-mongo/storage
 
 # Binaries
 manager/manager
@@ -16,4 +31,3 @@ worker/ethereum/sai-ethereum-contract-interaction/sai-eth-interaction
 worker/ethereum/sai-ethereum-indexer/cmd/app/bin/act
 worker/ethereum/sai-ethereum-indexer/cmd/app/ethereum-indexer
 worker/sai-storage-mongo/sai-storage-mongo
-worker/sai-storage-mongo/storage


### PR DESCRIPTION
Added trigger_sekin_update job to notify sekin repository of new interx releases with version and image details. Reorganized .gitignore with better categorization and added entries for docker-compose-unified.yml, init_network.sh, sekai/, and log directories.