### PR TITLE
Bugfix/41

### DIFF
--- a/manager/gateway/cosmos.go
+++ b/manager/gateway/cosmos.go
@@ -27,6 +27,9 @@ import (
 	kiraUbi "github.com/KiraCore/sai-interx-manager/proto-gen/kira/ubi"
 	kiraUpgrades "github.com/KiraCore/sai-interx-manager/proto-gen/kira/upgrade"
 
+	"github.com/KiraCore/sai-interx-manager/logger"
+	"github.com/KiraCore/sai-interx-manager/types"
+	"github.com/KiraCore/sai-service/service"
 	sekaitypes "github.com/KiraCore/sekai/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -41,9 +44,6 @@ import (
 	"github.com/cosmos/go-bip39"
 	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/KiraCore/sai-interx-manager/logger"
-	"github.com/KiraCore/sai-interx-manager/types"
-	"github.com/KiraCore/sai-service/service"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -277,7 +277,7 @@ func (g *CosmosGateway) Handle(data []byte) (interface{}, error) {
 	var req types.InboundRequest
 
 	if err := json.Unmarshal(data, &req); err != nil {
-		logger.Logger.Error("CosmosGateway - Handle - Unmarshal request failed", zap.Error(err))
+		logger.Logger.Error("CosmosGateway - Handle - Unmarshal request failed", zap.Error(err), zap.Any("req", req))
 		return nil, err
 	}
 

--- a/manager/gateway/cosmos_agregated3.go
+++ b/manager/gateway/cosmos_agregated3.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/KiraCore/sai-storage-mongo/external/adapter"
 	sekaitypes "github.com/KiraCore/sekai/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/KiraCore/sai-storage-mongo/external/adapter"
 	"go.uber.org/zap"
 
 	"github.com/KiraCore/sai-interx-manager/logger"
@@ -361,6 +361,8 @@ func (g *CosmosGateway) transactions(req types.InboundRequest) (interface{}, err
 		Limit:  sekaitypes.PageIterationLimit - 1,
 	}
 
+	logger.Logger.Debug("[query-transactions] request", zap.Any("req", req))
+
 	jsonData, err := json.Marshal(req.Payload)
 	if err != nil {
 		logger.Logger.Error("[query-transactions] Invalid request format", zap.Error(err))
@@ -374,32 +376,27 @@ func (g *CosmosGateway) transactions(req types.InboundRequest) (interface{}, err
 	}
 
 	sortMap := make(map[string]interface{})
-	if request.Sort != nil {
-		sortMap = request.Sort
-	} else if req.Payload["sort"] != nil {
-		sortStr, ok := req.Payload["sort"].(string)
-		if ok && sortStr != "" {
-			parts := strings.Split(sortStr, ":")
-			var field string
-			var direction string
+	if request.Sort != "" {
+		parts := strings.Split(request.Sort, ":")
+		var field string
+		var direction string
 
-			if len(parts) == 2 {
-				field = strings.TrimSpace(parts[0])
-				direction = strings.TrimSpace(parts[1])
-			} else if len(parts) == 1 {
-				field = "cr_time"
-				direction = strings.TrimSpace(parts[0])
-			}
+		if len(parts) == 2 {
+			field = strings.TrimSpace(parts[0])
+			direction = strings.TrimSpace(parts[1])
+		} else if len(parts) == 1 {
+			field = "cr_time"
+			direction = strings.TrimSpace(parts[0])
+		}
 
-			if field != "" {
-				var dirValue int
-				if direction == "desc" || direction == "-1" {
-					dirValue = -1
-				} else {
-					dirValue = 1
-				}
-				sortMap[field] = dirValue
+		if field != "" {
+			var dirValue int
+			if direction == "desc" || direction == "-1" {
+				dirValue = -1
+			} else {
+				dirValue = 1
 			}
+			sortMap[field] = dirValue
 		}
 	}
 
@@ -426,18 +423,18 @@ func (g *CosmosGateway) transactions(req types.InboundRequest) (interface{}, err
 		}
 	}
 
-	if request.StartDate > 0 {
+	if request.StartDate != "" {
 		criteria["timestamp"] = map[string]interface{}{
 			"$gt": request.StartDate,
 		}
 
-		if request.EndDate > 0 {
+		if request.EndDate != "" {
 			criteria["timestamp"] = map[string]interface{}{
 				"$gt": request.StartDate,
 				"$lt": request.EndDate,
 			}
 		}
-	} else if request.EndDate > 0 {
+	} else if request.EndDate != "" {
 		criteria["timestamp"] = map[string]interface{}{
 			"$lt": request.EndDate,
 		}
@@ -467,6 +464,11 @@ func (g *CosmosGateway) transactions(req types.InboundRequest) (interface{}, err
 		return nil, fmt.Errorf("directions filter requires address to be specified")
 	}
 
+	logger.Logger.Debug("[query-transactions] request",
+		zap.Any("request.Directions", request.Directions),
+		zap.Any("request.Address", request.Address),
+	)
+
 	if request.Address != "" {
 		orConditions := []map[string]interface{}{}
 
@@ -474,14 +476,31 @@ func (g *CosmosGateway) transactions(req types.InboundRequest) (interface{}, err
 			orConditions = []map[string]interface{}{
 				{"messages.from_address": request.Address},
 				{"messages.to_address": request.Address},
+				{"tx_result.events.attributes.value": request.Address},
 			}
 		} else {
 			for _, direction := range request.Directions {
 				switch direction {
 				case "inbound":
 					orConditions = append(orConditions, map[string]interface{}{"messages.to_address": request.Address})
+					orConditions = append(orConditions, map[string]interface{}{
+						"tx_result.events.attributes": map[string]interface{}{
+							"$elemMatch": map[string]interface{}{
+								"key":   "recipient",
+								"value": request.Address,
+							},
+						},
+					})
 				case "outbound":
 					orConditions = append(orConditions, map[string]interface{}{"messages.from_address": request.Address})
+					orConditions = append(orConditions, map[string]interface{}{
+						"tx_result.events.attributes": map[string]interface{}{
+							"$elemMatch": map[string]interface{}{
+								"key":   "sender",
+								"value": request.Address,
+							},
+						},
+					})
 				}
 			}
 		}

--- a/manager/gateway/cosmos_agregated3.go
+++ b/manager/gateway/cosmos_agregated3.go
@@ -425,18 +425,18 @@ func (g *CosmosGateway) transactions(req types.InboundRequest) (interface{}, err
 
 	if request.StartDate != "" {
 		criteria["timestamp"] = map[string]interface{}{
-			"$gt": request.StartDate,
+			"$gte": request.StartDate,
 		}
 
 		if request.EndDate != "" {
 			criteria["timestamp"] = map[string]interface{}{
-				"$gt": request.StartDate,
-				"$lt": request.EndDate,
+				"$gte": request.StartDate,
+				"$lte": request.EndDate,
 			}
 		}
 	} else if request.EndDate != "" {
 		criteria["timestamp"] = map[string]interface{}{
-			"$lt": request.EndDate,
+			"$lte": request.EndDate,
 		}
 	}
 
@@ -475,7 +475,7 @@ func (g *CosmosGateway) transactions(req types.InboundRequest) (interface{}, err
 		if len(request.Directions) == 0 {
 			orConditions = []map[string]interface{}{
 				{"messages.from_address": request.Address},
-				{"messages.to_address": request.Address},
+				{"pf": request.Address},
 				{"tx_result.events.attributes.value": request.Address},
 			}
 		} else {

--- a/manager/types/cosmos.go
+++ b/manager/types/cosmos.go
@@ -175,17 +175,17 @@ type TransactionResultResponse struct {
 }
 
 type QueryTxsParams struct {
-	Hash       string                 `json:"hash,omitempty"`
-	Height     string                 `json:"height,omitempty"`
-	Address    string                 `json:"address,omitempty"`
-	StartDate  int64                  `json:"start_date,string,omitempty"`
-	EndDate    int64                  `json:"end_date,string,omitempty"`
-	Directions []string               `json:"directions,omitempty"`
-	Statuses   []string               `json:"statuses,omitempty"`
-	Types      []string               `json:"types,omitempty"`
-	Offset     int                    `json:"offset,string,omitempty"`
-	Limit      int                    `json:"limit,string,omitempty"`
-	Sort       map[string]interface{} `json:"sort,omitempty"`
+	Hash       string   `json:"hash,omitempty"`
+	Height     string   `json:"height,omitempty"`
+	Address    string   `json:"address,omitempty"`
+	StartDate  string   `json:"start_date,string,omitempty"`
+	EndDate    string   `json:"end_date,string,omitempty"`
+	Directions []string `json:"directions,omitempty"`
+	Statuses   []string `json:"statuses,omitempty"`
+	Types      []string `json:"types,omitempty"`
+	Offset     int      `json:"offset,string,omitempty"`
+	Limit      int      `json:"limit,string,omitempty"`
+	Sort       string   `json:"sort,omitempty"`
 }
 
 type TxResponse struct {

--- a/manager/types/cosmos.go
+++ b/manager/types/cosmos.go
@@ -178,8 +178,8 @@ type QueryTxsParams struct {
 	Hash       string   `json:"hash,omitempty"`
 	Height     string   `json:"height,omitempty"`
 	Address    string   `json:"address,omitempty"`
-	StartDate  string   `json:"start_date,string,omitempty"`
-	EndDate    string   `json:"end_date,string,omitempty"`
+	StartDate  string   `json:"start_date,omitempty"`
+	EndDate    string   `json:"end_date,omitempty"`
 	Directions []string `json:"directions,omitempty"`
 	Statuses   []string `json:"statuses,omitempty"`
 	Types      []string `json:"types,omitempty"`

--- a/proxy/internal/service.go
+++ b/proxy/internal/service.go
@@ -51,10 +51,19 @@ func (is *InternalService) handleHttpConnections(w http.ResponseWriter, r *http.
 
 	if r.Method == "GET" {
 		queryParams := r.URL.Query()
-		paramMap := make(map[string]string)
+		paramMap := make(map[string]interface{})
 		for key, values := range queryParams {
 			if len(values) > 0 {
-				paramMap[key] = values[0]
+				normalizedKey := strings.TrimSuffix(key, "[]")
+				isArray := strings.HasSuffix(key, "[]")
+
+				if len(values) == 1 && strings.Contains(values[0], ",") {
+					paramMap[normalizedKey] = strings.Split(values[0], ",")
+				} else if isArray || len(values) > 1 {
+					paramMap[normalizedKey] = values
+				} else {
+					paramMap[normalizedKey] = values[0]
+				}
 			}
 		}
 		requestData = paramMap


### PR DESCRIPTION
Date 
/api/transactions?start_date=2025-11-17T16:45:35.710911842Z         (ISO format)

Sort
/api/transactions?sort=asc   (date is default field)  OR /api/transactions?sort=field_name:asc

Type
/api/transactions?types[]=/cosmos.bank.v1beta1.MsgSend     (transaction type as cosmos value)
We can add aliases (send, multisend and etc), but we should do it every time for a new transaction type added to the sekai. It's better to use proto naming.